### PR TITLE
Feature/upgrades dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,11 @@
 Change Log
 ==========
 
-* ⬆️ Bump com.android.tools.build:gradle from 7.4.2 to 8.0.0.
+* ⬆️ Bump com.android.tools.build:gradle from 7.4.2 to 8.0.2.
+* ⬆️ Uses ComposeBOM to manage compose dependencies.
+* ⬆️ Bumps Kotlin version to 1.8.22.
+* ⬆️ Bumps Appolo GraphQL to version to 3.8.2.
+* ⬆️ Bumps Navigation compose to version to 2.6.0.
 
 Version 1.0.3 *(2023-??-??)*
 ----------------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 Change Log
 ==========
 
+* ⬆️ Bump com.android.tools.build:gradle from 7.4.2 to 8.0.0.
+
 Version 1.0.3 *(2023-??-??)*
 ----------------------------
 

--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -55,6 +55,7 @@ android {
     }
 
     buildFeatures {
+        buildConfig = true
         compose = true
     }
     composeOptions {

--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -42,11 +42,11 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
     }
     kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_1_8.toString()
+        jvmTarget = JavaVersion.VERSION_17.toString()
 
         freeCompilerArgs = freeCompilerArgs + listOf(
             "-Xopt-in=kotlin.RequiresOptIn",
@@ -111,6 +111,7 @@ dependencies {
     }
 
     with(Compose) {
+        implementation(platform(composeBom))
         implementation(activity)
         implementation(coilCompose)
         implementation(material3)
@@ -147,14 +148,16 @@ dependencies {
     }
 
     with(AndroidTests) {
-        androidTestImplementation(androidXComposeUiTest)
-        androidTestImplementation(androidXTestCoreKtx)
-        androidTestImplementation(androidXTestRunner)
         androidTestImplementation(androidXTestRules)
         androidTestImplementation(androidXTestJUnitKtx)
         androidTestImplementation(androidXTestTruth)
         androidTestImplementation(androidXTestEspressoCore)
         androidTestImplementation(androidXTestEspressoContrib)
         androidTestImplementation(androidXTestEspressoIntents)
+
+        with(AndroidTests.Compose) {
+            // UI Tests
+            androidTestImplementation(uiTestComposeJUnit)
+        }
     }
 }

--- a/androidApp/proguard-rules.pro
+++ b/androidApp/proguard-rules.pro
@@ -15,3 +15,14 @@
 # CRASHLYTICS
 -keepattributes SourceFile,LineNumberTable        # Keep file names and line numbers.
 -keep public class * extends java.lang.Exception  # Optional: Keep custom exceptions.
+
+# Should not be needed after Appolo GraphQL upgrades OKHTTP to version 4.11
+-dontwarn org.bouncycastle.jsse.BCSSLParameters
+-dontwarn org.bouncycastle.jsse.BCSSLSocket
+-dontwarn org.bouncycastle.jsse.provider.BouncyCastleJsseProvider
+-dontwarn org.conscrypt.Conscrypt$Version
+-dontwarn org.conscrypt.Conscrypt
+-dontwarn org.conscrypt.ConscryptHostnameVerifier
+-dontwarn org.openjsse.javax.net.ssl.SSLParameters
+-dontwarn org.openjsse.javax.net.ssl.SSLSocket
+-dontwarn org.openjsse.net.ssl.OpenJSSE

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,7 +5,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath("com.android.tools.build:gradle:8.0.0")
+        classpath("com.android.tools.build:gradle:8.0.2")
         classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:${Versions.kotlinVersion}")
         classpath("com.google.dagger:hilt-android-gradle-plugin:${Versions.daggerVersion}")
         classpath("com.google.gms:google-services:${Versions.googleServicesVersion}")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,7 +5,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath("com.android.tools.build:gradle:7.4.2")
+        classpath("com.android.tools.build:gradle:8.0.0")
         classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:${Versions.kotlinVersion}")
         classpath("com.google.dagger:hilt-android-gradle-plugin:${Versions.daggerVersion}")
         classpath("com.google.gms:google-services:${Versions.googleServicesVersion}")

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -1,5 +1,5 @@
 object Versions {
-    const val kotlinVersion = "1.7.20"
+    const val kotlinVersion = "1.8.22"
 
     const val kotlinCoroutines = "1.6.4"
     const val kmpNativeCoroutines = "0.13.1"
@@ -10,20 +10,21 @@ object Versions {
 
     const val accompanistPager = "0.24.13-rc"
 
-    const val compose = "1.2.1"
-    const val composeCompiler = "1.3.2"
-    const val navCompose = "2.4.2"
+    const val composeBom = "2023.06.01"
+    const val composeCompiler = "1.4.8"
+    const val navCompose = "2.6.0"
     const val accompanist = "0.24.13-rc"
 
-    const val daggerVersion = "2.42"
+    const val daggerVersion = "2.46.1"
     const val hiltAndroidXVersion = "1.0.0"
 
     const val multiplatformSettings = "0.8.1"
 
-    const val junit = "4.13"
-    const val androidXTestVersion = "1.4.0"
-    const val androidXJUnitVersion = "1.1.3"
-    const val espresso = "3.3.0"
+    const val junit = "4.13.2"
+    const val androidXTestVersion = "1.5.0"
+    const val androidXTestRunnerVersion = "1.5.2"
+    const val androidXJUnitVersion = "1.1.5"
+    const val espresso = "3.5.0"
 }
 
 
@@ -34,7 +35,7 @@ object AndroidSdk {
 }
 
 object Apollo {
-    const val apolloVersion = "3.7.4"
+    const val apolloVersion = "3.8.2"
     const val apolloRuntime = "com.apollographql.apollo3:apollo-runtime:$apolloVersion"
     const val apolloNormalizedCache =
         "com.apollographql.apollo3:apollo-normalized-cache:$apolloVersion"
@@ -79,19 +80,20 @@ object Accompanist {
 }
 
 object Compose {
+    const val composeBom = "androidx.compose:compose-bom:${Versions.composeBom}"
     const val activity = "androidx.activity:activity-compose:1.5.0"
     const val compiler = "androidx.compose.compiler:compiler:${Versions.composeCompiler}"
-    const val ui = "androidx.compose.ui:ui:${Versions.compose}"
-    const val runtime = "androidx.compose.runtime:runtime:${Versions.compose}"
-    const val uiGraphics = "androidx.compose.ui:ui-graphics:${Versions.compose}"
-    const val uiTooling = "androidx.compose.ui:ui-tooling:${Versions.compose}"
-    const val uiToolingPreview = "androidx.compose.ui:ui-tooling-preview:${Versions.compose}"
-    const val foundationLayout = "androidx.compose.foundation:foundation-layout:${Versions.compose}"
-    const val material = "androidx.compose.material:material:${Versions.compose}"
+    const val ui = "androidx.compose.ui:ui"
+    const val runtime = "androidx.compose.runtime:runtime"
+    const val uiGraphics = "androidx.compose.ui:ui-graphics"
+    const val uiTooling = "androidx.compose.ui:ui-tooling"
+    const val uiToolingPreview = "androidx.compose.ui:ui-tooling-preview"
+    const val foundationLayout = "androidx.compose.foundation:foundation-layout"
+    const val material = "androidx.compose.material:material"
     const val material3 = "androidx.compose.material3:material3:1.0.0-beta02"
     const val materialIconsCore =
-        "androidx.compose.material:material-icons-core:${Versions.compose}"
-    const val materialIconsExtended = "androidx.compose.material:material-icons-extended:${Versions.compose}"
+        "androidx.compose.material:material-icons-core"
+    const val materialIconsExtended = "androidx.compose.material:material-icons-extended"
     const val navigation = "androidx.navigation:navigation-compose:${Versions.navCompose}"
     const val coilCompose = "io.coil-kt:coil-compose:2.1.0"
     const val hiltNavigation =
@@ -120,15 +122,14 @@ object Tests {
     const val kotlinJUnit = "org.jetbrains.kotlin:kotlin-test-junit:${Versions.kotlinVersion}"
 
     object Compose {
-        const val uiTestComposeJUnit = "androidx.compose.ui:ui-test-junit4:${Versions.compose}"
-        const val uiTestComposeManifest = "androidx.compose.ui:ui-test-junit4:${Versions.compose}"
+        const val uiTestComposeJUnit = "androidx.compose.ui:ui-test-junit4"
+        const val uiTestComposeManifest = "androidx.compose.ui:ui-test-junit4"
     }
 }
 
 object AndroidTests {
-    const val androidXComposeUiTest = "androidx.compose.ui:ui-test-junit4:${Versions.compose}"
     const val androidXTestCoreKtx = "androidx.test:core-ktx:${Versions.androidXTestVersion}"
-    const val androidXTestRunner = "androidx.test:runner:${Versions.androidXTestVersion}"
+    const val androidXTestRunner = "androidx.test:runner:${Versions.androidXTestRunnerVersion}"
     const val androidXTestRules = "androidx.test:rules:${Versions.androidXTestVersion}"
     const val androidXTestJUnitKtx = "androidx.test.ext:junit-ktx:${Versions.androidXJUnitVersion}"
     const val androidXTestTruth = "androidx.test.ext:truth:${Versions.androidXTestVersion}"
@@ -137,4 +138,8 @@ object AndroidTests {
         "androidx.test.espresso:espresso-contrib:${Versions.espresso}"
     const val androidXTestEspressoIntents =
         "androidx.test.espresso:espresso-intents:${Versions.espresso}"
+
+    object Compose {
+        const val uiTestComposeJUnit = "androidx.compose.ui:ui-test-junit4"
+    }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Tue Jun 14 11:19:33 CEST 2022
+#Mon Apr 24 19:16:41 CEST 2023
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip
 distributionPath=wrapper/dists
-zipStorePath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-bin.zip
 zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -85,4 +85,9 @@ android {
         minSdk = 23
     }
     namespace = "com.gdgnantes.devfest"
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
 }


### PR DESCRIPTION
* ⬆️ Bump com.android.tools.build:gradle from 7.4.2 to 8.0.2.
* ⬆️ Uses ComposeBOM to manage compose dependencies.
* ⬆️ Bumps Kotlin version to 1.8.22.
* ⬆️ Bumps Appolo GraphQL to version to 3.8.2.
* ⬆️ Bumps Navigation compose to version to 2.6.0.