### PR TITLE
⬆️ Bumps compose BOM to version 2023.09.00.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Version 2.0.2 *(2023-09-??)*
 
 * ⬆️ Bumps target SDK to Android 14.
 * ⬆️ Bumps firebase BOM to version 32.2.3.
-*
+* ⬆️ Bumps compose BOM to version 2023.09.00.
 
 Version 2.0.1 *(2023-09-12)*
 ----------------------------

--- a/androidApp/src/main/java/com/gdgnantes/devfest/androidapp/ui/screens/agenda/AgendaPager.kt
+++ b/androidApp/src/main/java/com/gdgnantes/devfest/androidapp/ui/screens/agenda/AgendaPager.kt
@@ -32,7 +32,9 @@ fun AgendaPager(
     onSessionClick: (Session) -> Unit,
 ) {
     Column(modifier = modifier.fillMaxWidth()) {
-        val pagerState = rememberPagerState(initialPage = initialPageIndex)
+        val pagerState = rememberPagerState(initialPage = initialPageIndex) {
+            days.size
+        }
 
         TabRow(
             // Our selected tab is our current page
@@ -63,7 +65,6 @@ fun AgendaPager(
         }
 
         HorizontalPager(
-            pageCount = days.size,
             state = pagerState,
         ) { page ->
             SwipeRefresh(

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -10,7 +10,7 @@ object Versions {
 
     const val accompanistPager = "0.24.13-rc"
 
-    const val composeBom = "2023.06.01"
+    const val composeBom = "2023.09.00"
     const val composeCompiler = "1.4.8"
     const val navCompose = "2.6.0"
     const val accompanist = "0.24.13-rc"


### PR DESCRIPTION
⬆️ Bumps compose BOM to version 2023.09.00.
Updates deprecated PagerState code.