### PR TITLE
chore: update compile SDK version to 36

### DIFF
--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -1,5 +1,5 @@
 object AndroidSdk {
     const val min = 23
-    const val compile = 34
+    const val compile = 36
     const val target = compile
 }


### PR DESCRIPTION
This pull request updates the Android SDK compile version to ensure compatibility with the latest tools and features.

* [`buildSrc/src/main/java/Dependencies.kt`](diffhunk://#diff-75b31066e97e27961c3c9e9668c539a133d73c10398dc76552df3f0119810ac0L3-R3): Updated the `compile` version in the `AndroidSdk` object from 34 to 36 to align with the latest Android SDK version.