### PR TITLE
Migrate from Material 2 to Material 3 Icon components

### DIFF
--- a/androidApp/src/main/java/com/gdgnantes/devfest/androidapp/ui/components/GithubCard.kt
+++ b/androidApp/src/main/java/com/gdgnantes/devfest/androidapp/ui/components/GithubCard.kt
@@ -6,8 +6,8 @@ import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material.Icon
 import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedCard
 import androidx.compose.material3.Text

--- a/androidApp/src/main/java/com/gdgnantes/devfest/androidapp/ui/components/SocialIcon.kt
+++ b/androidApp/src/main/java/com/gdgnantes/devfest/androidapp/ui/components/SocialIcon.kt
@@ -4,7 +4,7 @@ import androidx.annotation.DrawableRes
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.size
-import androidx.compose.material.Icon
+import androidx.compose.material3.Icon
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color

--- a/androidApp/src/main/java/com/gdgnantes/devfest/androidapp/ui/screens/agenda/AgendaColumn.kt
+++ b/androidApp/src/main/java/com/gdgnantes/devfest/androidapp/ui/screens/agenda/AgendaColumn.kt
@@ -10,9 +10,9 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
-import androidx.compose.material.Icon
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Schedule
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text

--- a/androidApp/src/main/java/com/gdgnantes/devfest/androidapp/ui/screens/agenda/AgendaRow.kt
+++ b/androidApp/src/main/java/com/gdgnantes/devfest/androidapp/ui/screens/agenda/AgendaRow.kt
@@ -8,10 +8,10 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material.Icon
-import androidx.compose.material.IconToggleButton
 import androidx.compose.material3.ElevatedCard
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconToggleButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable

--- a/androidApp/src/main/java/com/gdgnantes/devfest/androidapp/ui/screens/settings/SettingsTileIcon.kt
+++ b/androidApp/src/main/java/com/gdgnantes/devfest/androidapp/ui/screens/settings/SettingsTileIcon.kt
@@ -3,9 +3,9 @@ package com.gdgnantes.devfest.androidapp.ui.screens.settings
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.size
-import androidx.compose.material.Icon
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Clear
+import androidx.compose.material3.Icon
 import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable


### PR DESCRIPTION
This PR migrates all Icon components from Material 2 to Material 3 for consistency with the upgraded Compose BOM version 2025_06_00. It also fixes import ordering to comply with detekt rules.