### PR TITLE
Add iOS CI workflow for automated build and testing

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -129,6 +129,45 @@ jobs:
             echo "SwiftGen files already exist and are cached"
           fi
       
+      - name: Create mock GoogleService-Info.plist for CI
+        run: |
+          # Create a minimal mock GoogleService-Info.plist file for CI builds
+          cat > /Users/runner/Downloads/GoogleService-Info.plist << 'EOF'
+          <?xml version="1.0" encoding="UTF-8"?>
+          <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+          <plist version="1.0">
+          <dict>
+            <key>API_KEY</key>
+            <string>mock-api-key-for-ci</string>
+            <key>GCM_SENDER_ID</key>
+            <string>123456789</string>
+            <key>PLIST_VERSION</key>
+            <string>1</string>
+            <key>BUNDLE_ID</key>
+            <string>com.gdgnantes.devfest.iosApp</string>
+            <key>PROJECT_ID</key>
+            <string>mock-project-id</string>
+            <key>STORAGE_BUCKET</key>
+            <string>mock-project-id.appspot.com</string>
+            <key>IS_ADS_ENABLED</key>
+            <false/>
+            <key>IS_ANALYTICS_ENABLED</key>
+            <false/>
+            <key>IS_APPINVITE_ENABLED</key>
+            <false/>
+            <key>IS_GCM_ENABLED</key>
+            <true/>
+            <key>IS_SIGNIN_ENABLED</key>
+            <false/>
+            <key>GOOGLE_APP_ID</key>
+            <string>1:123456789:ios:mock-app-id</string>
+            <key>DATABASE_URL</key>
+            <string>https://mock-project-id.firebaseio.com</string>
+          </dict>
+          </plist>
+          EOF
+          echo "Created mock GoogleService-Info.plist for CI"
+      
       - name: List available schemes
         run: |
           echo "Listing project schemes and targets..."

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -130,15 +130,19 @@ jobs:
           fi
       
       - name: List available schemes
-        run: xcodebuild -project iosApp/iosApp.xcodeproj -list
+        run: |
+          echo "Listing project schemes and targets..."
+          xcodebuild -project iosApp/iosApp.xcodeproj -list
+          echo "Project listing complete."
       
       - name: Build iOS App for Simulator
         run: |
+          echo "Starting iOS build..."
           xcodebuild \
             -project iosApp/iosApp.xcodeproj \
             -scheme "iosApp" \
             -configuration Debug \
-            -destination 'platform=iOS Simulator,name=iPhone 16 Pro,OS=18.3' \
+            -destination 'platform=iOS Simulator,name=iPhone 16 Pro,OS=18.3.1' \
             -derivedDataPath build \
             build \
             CODE_SIGNING_ALLOWED=NO \

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -129,11 +129,14 @@ jobs:
             echo "SwiftGen files already exist and are cached"
           fi
       
+      - name: List available schemes
+        run: xcodebuild -project iosApp/iosApp.xcodeproj -list
+      
       - name: Build iOS App for Simulator
         run: |
           xcodebuild \
             -project iosApp/iosApp.xcodeproj \
-            -scheme "DevFest Nantes" \
+            -scheme "iosApp" \
             -configuration Debug \
             -destination 'platform=iOS Simulator,name=iPhone 16 Pro,OS=18.3' \
             -derivedDataPath build \

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -1,0 +1,69 @@
+name: iOS CI
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+  workflow_dispatch:
+
+env:
+  JAVA_VERSION: 17
+
+jobs:
+  ios-build:
+    name: iOS Build Check
+    runs-on: macos-15
+    timeout-minutes: 30
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'zulu'
+          java-version: ${{ env.JAVA_VERSION }}
+      
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+        with:
+          gradle-version: wrapper
+          cache-read-only: 'true'
+      
+      - name: Create local.properties
+        run: echo "sdk.dir=$ANDROID_HOME" > ./local.properties
+      
+      - name: Install SwiftGen
+        run: brew install swiftgen
+      
+      - name: Select Xcode version
+        run: sudo xcode-select -s /Applications/Xcode_16.2.app/Contents/Developer
+      
+      - name: Show Xcode version
+        run: xcodebuild -version
+      
+      - name: Show available simulators
+        run: xcrun simctl list devices available
+      
+      - name: Build shared framework
+        run: ./gradlew :shared:embedAndSignAppleFrameworkForXcode
+      
+      - name: Generate SwiftGen files
+        working-directory: iosApp/iosApp/SwiftGen
+        run: swiftgen config run
+      
+      - name: Build iOS App for Simulator
+        run: |
+          xcodebuild \
+            -project iosApp/iosApp.xcodeproj \
+            -scheme "DevFest Nantes" \
+            -configuration Debug \
+            -destination 'platform=iOS Simulator,name=iPhone 16 Pro,OS=18.1' \
+            -derivedDataPath build \
+            build \
+            CODE_SIGNING_ALLOWED=NO \
+            CODE_SIGNING_REQUIRED=NO \
+            CODE_SIGN_IDENTITY="" \
+            PROVISIONING_PROFILE=""

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -94,7 +94,20 @@ jobs:
         run: xcrun simctl list devices available
       
       - name: Build shared framework
-        run: ./gradlew :shared:embedAndSignAppleFrameworkForXcode
+        run: |
+          # Set required Xcode environment variables for the Gradle task
+          export SDK_NAME=iphonesimulator
+          export CONFIGURATION=Debug
+          export TARGET_BUILD_DIR=${{ github.workspace }}/build/ios
+          export BUILT_PRODUCTS_DIR=${{ github.workspace }}/build/ios
+          export FRAMEWORKS_FOLDER_PATH=Frameworks
+          export ARCHS=arm64
+          
+          # Create the target directory
+          mkdir -p "$TARGET_BUILD_DIR"
+          
+          # Run the Gradle task with Xcode environment
+          ./gradlew :shared:embedAndSignAppleFrameworkForXcode
       
       - name: Cache SwiftGen generated files
         uses: actions/cache@v4
@@ -122,7 +135,7 @@ jobs:
             -project iosApp/iosApp.xcodeproj \
             -scheme "DevFest Nantes" \
             -configuration Debug \
-            -destination 'platform=iOS Simulator,name=iPhone 16 Pro,OS=18.1' \
+            -destination 'platform=iOS Simulator,name=iPhone 16 Pro,OS=18.3' \
             -derivedDataPath build \
             build \
             CODE_SIGNING_ALLOWED=NO \

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -31,12 +31,58 @@ jobs:
         with:
           gradle-version: wrapper
           cache-read-only: 'true'
+          cache-cleanup: on-success
       
       - name: Create local.properties
         run: echo "sdk.dir=$ANDROID_HOME" > ./local.properties
       
+      - name: Cache Kotlin Multiplatform builds
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.konan
+            shared/build
+            shared/.gradle
+          key: ${{ runner.os }}-kmp-${{ hashFiles('shared/**/*.kt', 'shared/build.gradle.kts', 'gradle/libs.versions.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-kmp-
+      
+      - name: Cache Homebrew
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/Library/Caches/Homebrew
+            /usr/local/Homebrew
+          key: ${{ runner.os }}-homebrew-${{ hashFiles('**/Brewfile') }}
+          restore-keys: |
+            ${{ runner.os }}-homebrew-
+      
+      - name: Cache SwiftGen
+        uses: actions/cache@v4
+        with:
+          path: /usr/local/bin/swiftgen
+          key: ${{ runner.os }}-swiftgen-${{ hashFiles('iosApp/iosApp/SwiftGen/swiftgen.yml') }}
+          restore-keys: |
+            ${{ runner.os }}-swiftgen-
+      
       - name: Install SwiftGen
-        run: brew install swiftgen
+        run: |
+          if ! command -v swiftgen &> /dev/null; then
+            brew install swiftgen
+          else
+            echo "SwiftGen already installed"
+          fi
+      
+      - name: Cache Xcode DerivedData
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/Library/Developer/Xcode/DerivedData
+            build
+          key: ${{ runner.os }}-xcode-deriveddata-${{ hashFiles('iosApp/iosApp.xcodeproj/project.pbxproj') }}-${{ hashFiles('shared/**/*.kt') }}
+          restore-keys: |
+            ${{ runner.os }}-xcode-deriveddata-${{ hashFiles('iosApp/iosApp.xcodeproj/project.pbxproj') }}-
+            ${{ runner.os }}-xcode-deriveddata-
       
       - name: Select Xcode version
         run: sudo xcode-select -s /Applications/Xcode_16.2.app/Contents/Developer
@@ -50,9 +96,25 @@ jobs:
       - name: Build shared framework
         run: ./gradlew :shared:embedAndSignAppleFrameworkForXcode
       
+      - name: Cache SwiftGen generated files
+        uses: actions/cache@v4
+        with:
+          path: |
+            iosApp/iosApp/SwiftGen/Strings.swift
+            iosApp/iosApp/SwiftGen/Assets.swift
+          key: ${{ runner.os }}-swiftgen-generated-${{ hashFiles('iosApp/iosApp/Resources/**/*', 'iosApp/iosApp/SwiftGen/swiftgen.yml') }}
+          restore-keys: |
+            ${{ runner.os }}-swiftgen-generated-
+      
       - name: Generate SwiftGen files
         working-directory: iosApp/iosApp/SwiftGen
-        run: swiftgen config run
+        run: |
+          if [ ! -f "Strings.swift" ] || [ ! -f "Assets.swift" ]; then
+            echo "Generating SwiftGen files..."
+            swiftgen config run
+          else
+            echo "SwiftGen files already exist and are cached"
+          fi
       
       - name: Build iOS App for Simulator
         run: |


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow file, `.github/workflows/ios.yml`, to automate the CI pipeline for iOS development. The workflow includes steps for setting up dependencies, caching, building the shared framework, and generating SwiftGen files. It also prepares a mock `GoogleService-Info.plist` for CI builds and builds the iOS app for a simulator.

### New iOS CI Workflow:

* **Workflow Setup**: Added a new workflow named "iOS CI" that triggers on pushes and pull requests to the `main` branch, as well as manual dispatch. It runs on `macos-15` with a 30-minute timeout.

* **Dependency Setup**:
  - Configured Java using `actions/setup-java@v4` with Zulu distribution and Java 17.
  - Installed Gradle using `gradle/actions/setup-gradle@v4` with caching enabled for Gradle builds.

* **Caching**:
  - Implemented caching for Kotlin Multiplatform builds, Homebrew, SwiftGen, Xcode DerivedData, and SwiftGen-generated files to optimize build times.

* **SwiftGen Integration**:
  - Added steps to install SwiftGen if not already available and generate SwiftGen files if they are missing.

* **iOS Build Process