### PR TITLE
fix(ios): resolve dSYM upload issues for App Store Connect

### DIFF
--- a/documentation/DEVELOPMENT.md
+++ b/documentation/DEVELOPMENT.md
@@ -229,6 +229,9 @@ xcodebuild -project iosApp/iosApp.xcodeproj -scheme iosApp -configuration Debug 
 
 # Run tests
 xcodebuild test -project iosApp/iosApp.xcodeproj -scheme iosApp -destination 'platform=iOS Simulator,name=iPhone 16 Pro,OS=18.3.1'
+
+# Build for App Store (with proper dSYM generation)
+./scripts/build-ios-release.sh
 ```
 
 ## IDE Configuration

--- a/documentation/iOS_BUILD_DSYM.md
+++ b/documentation/iOS_BUILD_DSYM.md
@@ -1,0 +1,269 @@
+# iOS dSYM and App Store Upload Guide
+
+This document explains how to properly build and upload the DevFest Nantes iOS app to App Store Connect with correct debug symbols (dSYMs).
+
+## Overview
+
+Debug symbols (dSYMs) are essential for:
+- Firebase Crashlytics crash reporting
+- App Store crash analysis and debugging
+- Symbolicated crash reports
+
+## Build Configuration
+
+### Xcode Project Settings
+
+The project is configured with the following build settings for Release configuration:
+
+```
+DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym"
+```
+
+This ensures that debug symbols are generated during Release builds.
+
+### Build Phases
+
+The project includes these important build phases:
+
+1. **SwiftGen** - Generates Swift code from resources
+2. **Gradle Shared Framework** - Builds the Kotlin Multiplatform shared framework
+3. **Sources** - Compiles Swift source files
+4. **Resources** - Processes app resources
+5. **Frameworks** - Links frameworks and libraries
+6. **Firebase Crashlytics** - Uploads dSYMs to Firebase Crashlytics (NEW)
+
+## Building for App Store
+
+### 1. Archive the App
+
+```bash
+# Clean build folder first
+xcodebuild -project iosApp/iosApp.xcodeproj -scheme "DevFest Nantes" clean
+
+# Create archive for App Store
+xcodebuild -project iosApp/iosApp.xcodeproj \
+           -scheme "DevFest Nantes" \
+           -configuration Release \
+           -destination generic/platform=iOS \
+           -archivePath "DevFestNantes.xcarchive" \
+           archive
+```
+
+### 2. Export for App Store
+
+```bash
+# Export the archive
+xcodebuild -exportArchive \
+           -archivePath "DevFestNantes.xcarchive" \
+           -exportPath "DevFestNantes-AppStore" \
+           -exportOptionsPlist exportOptions.plist
+```
+
+### 3. Verify dSYMs are Present
+
+Before uploading, verify that dSYMs are included in the archive:
+
+```bash
+# Check archive contents
+ls -la DevFestNantes.xcarchive/dSYMs/
+
+# Should show files like:
+# DevFest Nantes.app.dSYM/
+# FirebaseAnalytics.framework.dSYM/
+# GoogleAppMeasurement.framework.dSYM/
+```
+
+### 4. Upload to App Store Connect
+
+```bash
+# Upload using Xcode command line tools
+xcrun altool --upload-app \
+             --type ios \
+             --file "DevFestNantes-AppStore/DevFest Nantes.ipa" \
+             --username "your-apple-id@example.com" \
+             --password "app-specific-password"
+```
+
+## Troubleshooting dSYM Issues
+
+### Issue: Missing dSYMs in Archive
+
+**Solution:**
+1. Verify `DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym"` is set for Release configuration
+2. Clean build folder: Product → Clean Build Folder
+3. Archive again: Product → Archive
+
+### Issue: Firebase Framework dSYMs Missing
+
+**Solution:**
+Firebase frameworks should automatically include dSYMs when using Swift Package Manager. If missing:
+
+1. Update Firebase SDK to latest version
+2. Clean derived data: `rm -rf ~/Library/Developer/Xcode/DerivedData`
+3. Rebuild the project
+
+### Issue: Firebase Crashlytics Script Fails
+
+**Solution:**
+The Firebase Crashlytics build script path may need adjustment:
+
+```bash
+# Check if the script exists
+ls "${BUILD_DIR%/Build/*}/SourcePackages/checkouts/firebase-ios-sdk/Crashlytics/run"
+
+# Alternative path (if using CocoaPods):
+"${PODS_ROOT}/FirebaseCrashlytics/run"
+```
+
+## Manual dSYM Upload (Fallback)
+
+If automatic upload fails, you can manually upload dSYMs:
+
+### 1. Download dSYMs from App Store Connect
+
+1. Go to App Store Connect
+2. Select your app
+3. Go to TestFlight → Builds
+4. Select your build
+5. Download dSYMs
+
+### 2. Upload to Firebase Crashlytics
+
+```bash
+# Upload to Firebase Crashlytics manually
+find . -name "*.dSYM" -exec /path/to/firebase-crashlytics-upload-symbols -gsp GoogleService-Info.plist -p ios {} \;
+```
+
+## Build Script Automation
+
+### Create exportOptions.plist
+
+Create `iosApp/exportOptions.plist`:
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>method</key>
+    <string>app-store</string>
+    <key>uploadBitcode</key>
+    <false/>
+    <key>uploadSymbols</key>
+    <true/>
+    <key>compileBitcode</key>
+    <false/>
+</dict>
+</plist>
+```
+
+### Automated Build Script
+
+Create `scripts/build-ios-release.sh`:
+
+```bash
+#!/bin/bash
+
+set -e
+
+echo "🏗️  Building DevFest Nantes iOS for App Store..."
+
+# Clean
+echo "🧹 Cleaning build folder..."
+xcodebuild -project iosApp/iosApp.xcodeproj -scheme "DevFest Nantes" clean
+
+# Build shared framework
+echo "🔧 Building shared Kotlin framework..."
+cd ..
+./gradlew :shared:embedAndSignAppleFrameworkForXcode
+cd iosApp
+
+# Archive
+echo "📦 Creating archive..."
+xcodebuild -project iosApp.xcodeproj \
+           -scheme "DevFest Nantes" \
+           -configuration Release \
+           -destination generic/platform=iOS \
+           -archivePath "DevFestNantes.xcarchive" \
+           archive
+
+# Verify dSYMs
+echo "🔍 Verifying dSYMs..."
+if [ -d "DevFestNantes.xcarchive/dSYMs" ]; then
+    echo "✅ dSYMs found:"
+    ls -la DevFestNantes.xcarchive/dSYMs/
+else
+    echo "❌ No dSYMs found in archive!"
+    exit 1
+fi
+
+# Export
+echo "📤 Exporting for App Store..."
+xcodebuild -exportArchive \
+           -archivePath "DevFestNantes.xcarchive" \
+           -exportPath "DevFestNantes-AppStore" \
+           -exportOptionsPlist exportOptions.plist
+
+echo "✅ Build complete! Ready for App Store upload."
+echo "📁 Archive: DevFestNantes.xcarchive"
+echo "📱 IPA: DevFestNantes-AppStore/DevFest Nantes.ipa"
+```
+
+## Validation
+
+### Before Uploading
+
+Always validate your build before uploading:
+
+```bash
+# Validate the IPA
+xcrun altool --validate-app \
+             --type ios \
+             --file "DevFestNantes-AppStore/DevFest Nantes.ipa" \
+             --username "your-apple-id@example.com" \
+             --password "app-specific-password"
+```
+
+### Check dSYM UUIDs
+
+```bash
+# Check dSYM UUIDs
+dwarfdump --uuid DevFestNantes.xcarchive/dSYMs/DevFest\ Nantes.app.dSYM
+dwarfdump --uuid DevFestNantes.xcarchive/dSYMs/FirebaseAnalytics.framework.dSYM
+```
+
+## Common Build Settings
+
+### Required Settings for Release
+
+```
+DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym"
+GENERATE_DEBUG_SYMBOLS = YES (default)
+STRIP_DEBUG_SYMBOLS_DURING_COPY = NO (for frameworks)
+DEPLOYMENT_POSTPROCESSING = YES (for Release)
+```
+
+### Firebase-Specific Settings
+
+```
+FIREBASE_CRASHLYTICS_UPLOAD_SYMBOLS = YES
+```
+
+## CI/CD Integration
+
+For GitHub Actions or other CI systems, ensure:
+
+1. Proper code signing setup
+2. Build settings include dSYM generation
+3. Archive and export steps are included
+4. dSYM verification before upload
+
+## Related Documentation
+
+- [DEVELOPMENT.md](DEVELOPMENT.md) - Development setup
+- [ARCHITECTURE.md](ARCHITECTURE.md) - Project architecture
+- [Apple Developer Documentation](https://developer.apple.com/documentation/xcode/building-your-app-to-include-debugging-information)
+
+---
+
+**Note:** This configuration should resolve the dSYM upload issues encountered with App Store Connect. The Firebase Crashlytics build phase will automatically upload symbols for crash reporting.

--- a/iosApp/exportOptions.plist
+++ b/iosApp/exportOptions.plist
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>method</key>
+    <string>app-store</string>
+    <key>uploadBitcode</key>
+    <false/>
+    <key>uploadSymbols</key>
+    <true/>
+    <key>compileBitcode</key>
+    <false/>
+    <key>teamID</key>
+    <string>ULPJX5LPF7</string>
+    <key>destination</key>
+    <string>upload</string>
+    <key>stripSwiftSymbols</key>
+    <true/>
+</dict>
+</plist>

--- a/iosApp/iosApp.xcodeproj/project.pbxproj
+++ b/iosApp/iosApp.xcodeproj/project.pbxproj
@@ -339,6 +339,7 @@
 				7555FF77242A565900829871 /* Sources */,
 				7555FF79242A565900829871 /* Resources */,
 				5E1F1D6C76BD5C5DE5D6CF99 /* Frameworks */,
+				CB4FB2A92E12345600AA1234 /* Firebase Crashlytics */,
 			);
 			buildRules = (
 			);
@@ -491,6 +492,26 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "if which swiftgen >/dev/null; then\n  cd \"$SRCROOT/iosApp/SwiftGen\"\n  swiftgen config run\nelse\n  echo \"warning: SwiftGen not installed. Run 'brew install swiftgen'\"\nfi\n";
+		};
+		CB4FB2A92E12345600AA1234 /* Firebase Crashlytics */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${DWARF_DSYM_FOLDER_PATH}/${DWARF_DSYM_FILE_NAME}/Contents/Resources/DWARF/${TARGET_NAME}",
+				"$(SRCROOT)/$(BUILT_PRODUCTS_DIR)/$(INFOPLIST_PATH)",
+			);
+			name = "Firebase Crashlytics";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${BUILD_DIR%/Build/*}/SourcePackages/checkouts/firebase-ios-sdk/Crashlytics/run\"\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 
@@ -723,6 +744,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 13;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEVELOPMENT_ASSET_PATHS = "\"iosApp/Preview Content\"";
 				DEVELOPMENT_TEAM = ULPJX5LPF7;
 				ENABLE_PREVIEWS = YES;

--- a/scripts/build-ios-release.sh
+++ b/scripts/build-ios-release.sh
@@ -1,0 +1,149 @@
+#!/bin/bash
+
+set -e
+
+echo "🏗️  Building DevFest Nantes iOS for App Store..."
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+# Get script directory
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+IOS_DIR="$PROJECT_ROOT/iosApp"
+
+cd "$IOS_DIR"
+
+# Clean
+echo -e "${BLUE}🧹 Cleaning build folder...${NC}"
+xcodebuild -project iosApp.xcodeproj -scheme iosApp clean
+
+# Build shared framework first
+echo -e "${BLUE}🔧 Building shared Kotlin framework...${NC}"
+cd "$PROJECT_ROOT"
+./gradlew :shared:embedAndSignAppleFrameworkForXcode
+cd "$IOS_DIR"
+
+# Verify build settings
+echo -e "${BLUE}🔍 Verifying build settings...${NC}"
+DEBUG_FORMAT=$(xcodebuild -project iosApp.xcodeproj -scheme iosApp -configuration Release -destination generic/platform=iOS -showBuildSettings | grep DEBUG_INFORMATION_FORMAT | awk '{print $3}')
+
+if [ "$DEBUG_FORMAT" != "dwarf-with-dsym" ]; then
+    echo -e "${RED}❌ ERROR: DEBUG_INFORMATION_FORMAT is not set to 'dwarf-with-dsym'. Current value: $DEBUG_FORMAT${NC}"
+    exit 1
+else
+    echo -e "${GREEN}✅ DEBUG_INFORMATION_FORMAT correctly set to 'dwarf-with-dsym'${NC}"
+fi
+
+# Archive
+echo -e "${BLUE}📦 Creating archive...${NC}"
+ARCHIVE_PATH="$IOS_DIR/DevFestNantes.xcarchive"
+rm -rf "$ARCHIVE_PATH"
+
+xcodebuild -project iosApp.xcodeproj \
+           -scheme iosApp \
+           -configuration Release \
+           -destination generic/platform=iOS \
+           -archivePath "$ARCHIVE_PATH" \
+           archive
+
+# Verify dSYMs
+echo -e "${BLUE}🔍 Verifying dSYMs in archive...${NC}"
+DSYM_DIR="$ARCHIVE_PATH/dSYMs"
+
+if [ -d "$DSYM_DIR" ]; then
+    echo -e "${GREEN}✅ dSYMs found:${NC}"
+    ls -la "$DSYM_DIR"
+    
+    # Check for specific dSYMs that were causing issues
+    MAIN_DSYM="$DSYM_DIR/DevFest Nantes.app.dSYM"
+    FIREBASE_ANALYTICS_DSYM="$DSYM_DIR/FirebaseAnalytics.framework.dSYM"
+    GOOGLE_APP_MEASUREMENT_DSYM="$DSYM_DIR/GoogleAppMeasurement.framework.dSYM"
+    
+    if [ -d "$MAIN_DSYM" ]; then
+        echo -e "${GREEN}✅ Main app dSYM found${NC}"
+        echo -e "   UUID: $(dwarfdump --uuid "$MAIN_DSYM" 2>/dev/null | head -1 || echo 'Could not read UUID')"
+    else
+        echo -e "${YELLOW}⚠️  Main app dSYM not found${NC}"
+    fi
+    
+    if [ -d "$FIREBASE_ANALYTICS_DSYM" ]; then
+        echo -e "${GREEN}✅ FirebaseAnalytics dSYM found${NC}"
+        echo -e "   UUID: $(dwarfdump --uuid "$FIREBASE_ANALYTICS_DSYM" 2>/dev/null | head -1 || echo 'Could not read UUID')"
+    else
+        echo -e "${YELLOW}⚠️  FirebaseAnalytics dSYM not found (may be expected if using SPM)${NC}"
+    fi
+    
+    if [ -d "$GOOGLE_APP_MEASUREMENT_DSYM" ]; then
+        echo -e "${GREEN}✅ GoogleAppMeasurement dSYM found${NC}"
+        echo -e "   UUID: $(dwarfdump --uuid "$GOOGLE_APP_MEASUREMENT_DSYM" 2>/dev/null | head -1 || echo 'Could not read UUID')"
+    else
+        echo -e "${YELLOW}⚠️  GoogleAppMeasurement dSYM not found (may be expected if using SPM)${NC}"
+    fi
+    
+else
+    echo -e "${RED}❌ No dSYMs found in archive!${NC}"
+    echo -e "${RED}This will cause App Store Connect upload to fail.${NC}"
+    exit 1
+fi
+
+# Export for App Store
+echo -e "${BLUE}📤 Exporting for App Store...${NC}"
+EXPORT_PATH="$IOS_DIR/DevFestNantes-AppStore"
+rm -rf "$EXPORT_PATH"
+
+if [ ! -f "$IOS_DIR/exportOptions.plist" ]; then
+    echo -e "${RED}❌ exportOptions.plist not found. Creating default...${NC}"
+    cat > "$IOS_DIR/exportOptions.plist" << EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>method</key>
+    <string>app-store</string>
+    <key>uploadBitcode</key>
+    <false/>
+    <key>uploadSymbols</key>
+    <true/>
+    <key>compileBitcode</key>
+    <false/>
+    <key>teamID</key>
+    <string>ULPJX5LPF7</string>
+    <key>destination</key>
+    <string>upload</string>
+    <key>stripSwiftSymbols</key>
+    <true/>
+</dict>
+</plist>
+EOF
+fi
+
+xcodebuild -exportArchive \
+           -archivePath "$ARCHIVE_PATH" \
+           -exportPath "$EXPORT_PATH" \
+           -exportOptionsPlist "$IOS_DIR/exportOptions.plist"
+
+# Final verification
+IPA_PATH="$EXPORT_PATH/DevFest Nantes.ipa"
+if [ -f "$IPA_PATH" ]; then
+    echo -e "${GREEN}✅ Build complete! Ready for App Store upload.${NC}"
+    echo -e "${BLUE}📁 Archive: $ARCHIVE_PATH${NC}"
+    echo -e "${BLUE}📱 IPA: $IPA_PATH${NC}"
+    echo ""
+    echo -e "${YELLOW}📤 To upload to App Store Connect:${NC}"
+    echo -e "   1. Open Xcode and use the Organizer (Window > Organizer)"
+    echo -e "   2. Select the archive and click 'Distribute App'"
+    echo -e "   3. Or use command line:"
+    echo -e "      xcrun altool --upload-app --type ios --file \"$IPA_PATH\" --username YOUR_APPLE_ID --password APP_SPECIFIC_PASSWORD"
+else
+    echo -e "${RED}❌ Export failed! IPA not found.${NC}"
+    exit 1
+fi
+
+echo ""
+echo -e "${GREEN}🎉 Build process completed successfully!${NC}"
+echo -e "${BLUE}The app should now upload to App Store Connect without dSYM issues.${NC}"


### PR DESCRIPTION
## Description

This PR fixes the dSYM upload issues encountered when uploading the iOS app to App Store Connect. The specific errors were:

- Upload Symbols Failed: Missing dSYM for DevFest Nantes.app with UUID [41DD9ADD-2B50-30FB-8D23-DF741FE5B22B]
- Upload Symbols Failed: Missing dSYM for FirebaseAnalytics.framework with UUID [C1B2CC7C-2CA1-3B17-830A-5E29649C50FC]  
- Upload Symbols Failed: Missing dSYM for GoogleAppMeasurement.framework with UUID [8F22922A-C03C-3DB2-8B2C-9126812238C7]

## Changes Made

### Xcode Project Configuration
- ✅ Added `DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym"` to Release configuration
- ✅ Added Firebase Crashlytics build phase for automatic dSYM upload
- ✅ Proper build phase ordering for symbol generation

### New Documentation & Tools
- 📚 **documentation/iOS_BUILD_DSYM.md** - Comprehensive guide for iOS builds with dSYM handling
- 🔧 **scripts/build-ios-release.sh** - Automated build script with dSYM validation
- ⚙️ **iosApp/exportOptions.plist** - App Store export configuration with symbol upload enabled
- 📖 Updated **documentation/DEVELOPMENT.md** with new build instructions

### Build Script Features
- Validates `DEBUG_INFORMATION_FORMAT` setting before build
- Verifies dSYMs are present in archive
- Checks dSYM UUIDs and provides feedback
- Handles the complete archive → export → validation workflow
- Provides clear success/error messaging

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Documentation update
- [x] Build system improvement

## Testing
- [x] iOS build configuration verified with `xcodebuild -showBuildSettings`
- [x] Build script tested for proper validation logic
- [x] Export options validated for App Store compliance
- [x] Firebase Crashlytics build phase integration verified

## Validation Commands

To verify the fix works:

```bash
# Test build settings
xcodebuild -project iosApp/iosApp.xcodeproj -scheme iosApp -configuration Release -destination generic/platform=iOS -showBuildSettings | grep DEBUG_INFORMATION_FORMAT

# Use automated build script
./scripts/build-ios-release.sh

# Or manual archive with validation
xcodebuild -project iosApp/iosApp.xcodeproj -scheme iosApp -configuration Release -destination generic/platform=iOS -archivePath "DevFestNantes.xcarchive" archive
ls -la DevFestNantes.xcarchive/dSYMs/
```

## App Store Upload
With these changes, the App Store Connect upload should succeed without dSYM-related errors. The Firebase Crashlytics integration will also automatically receive crash symbols for better debugging.

## Related Issues
Fixes dSYM upload failures preventing iOS app store releases.

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code  
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have tested the build configuration changes