### PR TITLE
feat(android): migrate SwipeRefresh to PullRefresh and customize indicator for Material3 design

### DIFF
--- a/androidApp/src/main/java/com/gdgnantes/devfest/androidapp/ui/screens/agenda/AgendaPager.kt
+++ b/androidApp/src/main/java/com/gdgnantes/devfest/androidapp/ui/screens/agenda/AgendaPager.kt
@@ -1,12 +1,18 @@
-@file:OptIn(ExperimentalFoundationApi::class)
+@file:OptIn(ExperimentalFoundationApi::class, ExperimentalMaterialApi::class)
 
 package com.gdgnantes.devfest.androidapp.ui.screens.agenda
 
 import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
+import androidx.compose.material.ExperimentalMaterialApi
+import androidx.compose.material.pullrefresh.PullRefreshIndicator
+import androidx.compose.material.pullrefresh.pullRefresh
+import androidx.compose.material.pullrefresh.rememberPullRefreshState
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Tab
 import androidx.compose.material3.TabRow
 import androidx.compose.material3.TabRowDefaults
@@ -14,6 +20,7 @@ import androidx.compose.material3.TabRowDefaults.tabIndicatorOffset
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import com.gdgnantes.devfest.androidapp.ui.UiState
@@ -21,8 +28,6 @@ import com.gdgnantes.devfest.androidapp.ui.components.LoadingLayout
 import com.gdgnantes.devfest.androidapp.utils.getDayFromIso8601
 import com.gdgnantes.devfest.model.AgendaDay
 import com.gdgnantes.devfest.model.Session
-import com.google.accompanist.swiperefresh.SwipeRefresh
-import com.google.accompanist.swiperefresh.SwipeRefreshState
 import kotlinx.coroutines.launch
 
 @Composable
@@ -45,7 +50,7 @@ fun AgendaPager(
             selectedTabIndex = pagerState.currentPage,
             // Override the indicator, using the provided pagerTabIndicatorOffset modifier
             indicator = { tabPositions ->
-                TabRowDefaults.Indicator(
+                TabRowDefaults.SecondaryIndicator(
                     Modifier.tabIndicatorOffset(
                         tabPositions[pagerState.currentPage]
                     )
@@ -72,10 +77,9 @@ fun AgendaPager(
         HorizontalPager(
             state = pagerState,
         ) { page ->
-            SwipeRefresh(
-                state = SwipeRefreshState(isRefreshing = uiState == UiState.LOADING),
-                onRefresh = onRefresh,
-            ) {
+            val isRefreshing = uiState == UiState.LOADING
+            val pullRefreshState = rememberPullRefreshState(isRefreshing, onRefresh)
+            Box(modifier = Modifier.pullRefresh(pullRefreshState)) {
                 if (uiState == UiState.STARTING) {
                     LoadingLayout()
                 } else {
@@ -89,6 +93,14 @@ fun AgendaPager(
                         )
                     }
                 }
+                PullRefreshIndicator(
+                    refreshing = isRefreshing,
+                    state = pullRefreshState,
+                    modifier = Modifier.align(Alignment.TopCenter),
+                    contentColor = MaterialTheme.colorScheme.primary,
+                    backgroundColor = MaterialTheme.colorScheme.surface,
+                    scale = true // enables Material3-style scaling animation
+                )
             }
         }
     }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -36,7 +36,6 @@ timber = "5.0.1"
 accompanist-pager = { group = "com.google.accompanist", name = "accompanist-pager", version.ref = "accompanist" }
 accompanist-pager-indicators = { group = "com.google.accompanist", name = "accompanist-pager-indicators", version.ref = "accompanist" }
 accompanist-systemuicontroller = { group = "com.google.accompanist", name = "accompanist-systemuicontroller", version.ref = "accompanist" }
-accompanist-swiperefresh = { group = "com.google.accompanist", name = "accompanist-swiperefresh", version.ref = "accompanist" }
 
 androidx-browser = { group = "androidx.browser", name = "browser", version.ref = "browser" }
 androidx-compose-bom = { module = "androidx.compose:compose-bom", version.ref = "composeBom" }
@@ -104,7 +103,7 @@ openfeedback-viewmodel = { module = "io.openfeedback:openfeedback-viewmodel", ve
 timber = { module = "com.jakewharton.timber:timber", version.ref = "timber" }
 
 [bundles]
-accompanist = ["accompanist-pager", "accompanist-pager-indicators", "accompanist-systemuicontroller", "accompanist-swiperefresh"]
+accompanist = ["accompanist-pager", "accompanist-pager-indicators", "accompanist-systemuicontroller"]
 android-test = ["androidx-compose-ui-test-junit4", "androidx-test-espresso", "androidx-test-espresso-contrib", "androidx-test-espresso-intents", "androidx-test-ext-junit", "androidx-test-rules", "androidx-test-truth"]
 appollo = ["appollo-runtime", "appollo-normalized-cache", "appollo-normalized-cache-sqlite"]
 debug = ["androidx-compose-ui-tooling", "androidx-compose-ui-test-manifest"]


### PR DESCRIPTION
## Description
Migrates the Agenda screen from the deprecated SwipeRefresh to the recommended PullRefresh API. The pull-to-refresh indicator is customized to match Material3 design using MaterialTheme colorScheme. This ensures visual consistency and future-proofs the refresh experience.

## Type of Change
- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] 🎨 Style/formatting changes (no functional changes)
- [x] ♻️ Code refactoring (no functional changes)

## Related Issues
Fixes # (no direct issue, but addresses Compose deprecation warning)

## Changes Made
- Migrated from SwipeRefresh to PullRefresh in AgendaPager.kt
- Customized PullRefreshIndicator to use Material3 colors and scaling animation
- Updated gradle/libs.versions.toml for dependency alignment
- Refactored code to remove deprecated and unused imports

## Platform Testing

### Android
- [x] 📱 Android build passes
- [x] 📲 Manual testing on Android device/emulator
- [x] 🎨 UI/UX verified on different screen sizes

### iOS (if applicable)
- [ ] 🍎 iOS build passes
- [ ] 📱 Manual testing on iOS device/simulator

### Shared Module
- [x] 🔄 Shared module builds successfully
